### PR TITLE
Fix for  #3 and other improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,8 @@
 export class Whirlpool {
+    constructor(options?: {
+        type?: 't' | '0' | '',
+        rounds?: number
+    });
     getHash(message: String): String;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export class Whirlpool {
         type?: 't' | '0' | '',
         rounds?: number
     });
-    getHash(message: String): String;
+    getHash(message: string): string;
 }
 
 export namespace encoders {

--- a/index.js
+++ b/index.js
@@ -571,9 +571,9 @@
          */
         finalize() {
             this.addPaddingISO7816(
-                this.state.message.length < 56 ?
-                    56 - this.state.message.length | 0 :
-                    120 - this.state.message.length | 0);
+                this.state.message.length < 32 ?
+                    (56 - this.state.message.length) | 0 :
+                    (120 - this.state.message.length) | 0);
             this.addLengthBits();
             this.process();
             return this.getStateHash();


### PR DESCRIPTION
I have fixed the calculation of strings of more than 31 characters based on commit https://github.com/nf404/crypto-api/commit/b7dedd2eaed78d209f6063e20c809d90b96f0e5b which is more or less the same algorithm. This fixed #3 

Also, I have updated the typescript definition with the options that are available in the js file and changed the String type to string in the getHash function that I think you'd forgotten to change. This fixed #2 